### PR TITLE
Changed the Tenderly domain from .dev to .co

### DIFF
--- a/docs/translations/ar/developers/index.md
+++ b/docs/translations/ar/developers/index.md
@@ -125,7 +125,7 @@ sidebarDepth: 1
 
 **Tenderly -** **_منصة لمراجعة العقود الذكية بسهولة من خلال تتبع الأخطاء والتنبيه و قياس الأداء وتحليلات مفصلة للعقود ._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/fa/developers/index.md
+++ b/docs/translations/fa/developers/index.md
@@ -122,7 +122,7 @@ sidebarDepth: 1
 
 **تندرلی (Tenderly)** _پلتفرمی برای نظارت آسان بر قرارداد‌های هوشمند شما، همراه با ردیابی خطا‌ها، اعلام خطر‌ها، ارزیابی‌های کارایی، و تحلیل جزئیات قرارداد._
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/id/developers/index.md
+++ b/docs/translations/id/developers/index.md
@@ -123,7 +123,7 @@ Ethereum punya banyak perangkat yang jumlahnya terus bertambah yang dapat diguna
 
 **Tenderly -** **_Sebuah platform untuk memonitor smart contracts dengan fitur pelacakan kesalahan, alerting, metrik kinerja, dan analitik kontrak yang detail._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/se/developers/index.md
+++ b/docs/translations/se/developers/index.md
@@ -123,7 +123,7 @@ Ethereum har ett stort och växande antal verktyg som hjälper utvecklare att by
 
 **Tenderly -** **_En plattform för att enkelt övervaka din smarta kontrakt med felspårning, larm, prestandavärden och detaljerad kontraktsanalys._**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 

--- a/docs/translations/sk/developers/index.md
+++ b/docs/translations/sk/developers/index.md
@@ -123,7 +123,7 @@ Ethereum ponúka čoraz viac nástrojov, ktoré vývojárom pomáhajú vytvára�
 
 **Tenderly -** **_platforma na jednoduché monitorovanie smart kontraktov so sledovaním chýb, výstrahami, meraním výkonnostných metrík a podrobnými analýzami kontraktov_**
 
-- [tenderly.dev](https://tenderly.dev/)
+- [tenderly.co](https://tenderly.co/)
 - [GitHub](https://github.com/Tenderly)
 - [Discord](https://discord.gg/eCWjuvt)
 


### PR DESCRIPTION
As the title suggests, Tenderly is moving to a new domain, and this PR reflects that change.